### PR TITLE
Restructure to enable different acquirables

### DIFF
--- a/src/DotNetInstallSdk/Acquirables/Acquireable.cs
+++ b/src/DotNetInstallSdk/Acquirables/Acquireable.cs
@@ -1,0 +1,12 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DotNet.InstallSdk.Acquirables
+{
+    public abstract class Acquirable
+    {
+        protected readonly string ReleaseIndex = "https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json";
+        
+        public abstract Task<AcquireResult> Fetch(HttpClient httpClient);
+    }
+}

--- a/src/DotNetInstallSdk/Acquirables/GlobalJsonVersion.cs
+++ b/src/DotNetInstallSdk/Acquirables/GlobalJsonVersion.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace DotNet.InstallSdk.Acquirables
+{
+    public class GlobalJsonVersion : Acquirable
+    {
+        readonly string _version;
+
+        public GlobalJsonVersion(ITextWriter writer)
+        {
+            _version = new GlobalJsonLocator(writer).Parse().Sdk.Version;
+        }
+
+        
+        static string ParseChannelVersion(string version)
+        {
+            var channelVersion = version.Substring(0, 3);
+            if (!char.IsDigit(channelVersion[0]) || channelVersion[1] != '.' || !char.IsDigit(channelVersion[2]))
+                throw new ArgumentException(@"Parsing channel version failed, expected a major.minor format. e.g. ""2.1""", nameof(version));
+            return channelVersion;
+        }
+
+        public override async Task<AcquireResult> Fetch(HttpClient httpClient)
+        {
+            var channelVersion = ParseChannelVersion(_version);
+
+            using var releasesResponse = await JsonDocument.ParseAsync(await httpClient.GetStreamAsync(ReleaseIndex));
+
+            var channel = releasesResponse.RootElement.GetProperty("releases-index").EnumerateArray()
+                .First(x => x.GetProperty("channel-version").GetString() == channelVersion);
+
+            var channelJson = channel.GetProperty("releases.json").GetString();
+            
+            return new AcquireResult
+            {
+                ChannelJson = channelJson,
+                Version = _version
+            };
+        }
+    }
+
+    public class AcquireResult
+    {
+        public string Version { get; set; }
+
+        public string ChannelJson { get; set; }
+    }
+}

--- a/src/DotNetInstallSdk/CommandLineArguments.cs
+++ b/src/DotNetInstallSdk/CommandLineArguments.cs
@@ -1,0 +1,9 @@
+namespace DotNet.InstallSdk
+{
+    public class CommandLineArguments
+    {
+        public bool Latest { get; set; }
+
+        public bool LatestPreview { get; set; }
+    }
+}

--- a/src/DotNetInstallSdk/DotNetInstallSdk.csproj
+++ b/src/DotNetInstallSdk/DotNetInstallSdk.csproj
@@ -8,18 +8,19 @@
         <PackageTags>global tool;install sdk</PackageTags>
         <ToolCommandName>dotnet-install-sdk</ToolCommandName>
         <LangVersion>8</LangVersion>
-        <VersionPrefix>2.0.0</VersionPrefix>
+        <VersionPrefix>2.0.1</VersionPrefix>
         <PackageId>InstallSdkGlobalTool</PackageId>
         <Authors>Joseph Woodward, Stuart Lang</Authors>
         <Description>A .NET Core Global Tool for installing .NET Core SDK versions based on global.json files</Description>
         <PackageProjectUrl>https://github.com/JosephWoodward/DotNetInstallSdkGlobalTool/</PackageProjectUrl>
-        <RepositoryUrl>>https://github.com/JosephWoodward/DotNetInstallSdkGlobalTool.git</RepositoryUrl> 
+        <RepositoryUrl>https://github.com/JosephWoodward/DotNetInstallSdkGlobalTool.git</RepositoryUrl> 
         <RepositoryType>git</RepositoryType> 
         <PackageLicenseUrl>https://github.com/JosephWoodward/DotNetInstallSdkGlobalTool/blob/master/LICENSE</PackageLicenseUrl> 
         <RootNamespace>DotNet.InstallSdk</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
         <PackageReference Include="System.Text.Json" Version="4.6.0-preview7.19362.9" />
     </ItemGroup>
 

--- a/src/DotNetInstallSdk/InstallSdkTool.cs
+++ b/src/DotNetInstallSdk/InstallSdkTool.cs
@@ -1,22 +1,22 @@
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using DotNet.InstallSdk.Acquirables;
 
 namespace DotNet.InstallSdk
 {
     public static class InstallSdkTool
     {
-        public static void Run()
+        public static void Run(CommandLineArguments args)
         {
             var writer = new ConsoleTextWriter();
-            var locator = new GlobalJsonLocator(writer);
 
             try
             {
-                var version = locator.Parse().Sdk.Version;
-
+                var v = new GlobalJsonVersion(writer);
+                
                 var sdkAcquirer = new SdkAcquirer(new HttpClient(), writer, new InstallerLauncher(), new PlatformIdentifier());
-                sdkAcquirer.Acquire(version).GetAwaiter().GetResult();
+                sdkAcquirer.Acquire(v).GetAwaiter().GetResult();
             }
             catch (FileNotFoundException e)
             {

--- a/src/DotNetInstallSdk/Program.cs
+++ b/src/DotNetInstallSdk/Program.cs
@@ -1,8 +1,26 @@
-﻿namespace DotNet.InstallSdk
+﻿using McMaster.Extensions.CommandLineUtils;
+
+namespace DotNet.InstallSdk
 {
     class Program
     {
-        static void Main(string[] args)
-            => InstallSdkTool.Run();
+        public static int Main(string[] args)
+            => CommandLineApplication.Execute<Program>(args);
+
+/*
+        [Option("-LP|--latest-preview", Description = "Install the latest preview version of the .NET Core SDK")]
+        public bool LatestPreview { get; } = false;
+
+        [Option("-L|--latest", Description = "Install the latest non-preview version of the .NET Core SDK")]
+        public bool Latest { get; } = false;
+*/
+        private void OnExecute()
+        {
+            InstallSdkTool.Run(new CommandLineArguments
+            {
+                Latest = false,
+                LatestPreview = false
+            });
+        }
     }
 }

--- a/tests/DotNetInstallSdk.Tests/UnitTest1.cs
+++ b/tests/DotNetInstallSdk.Tests/UnitTest1.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using DotNet.InstallSdk.Acquirables;
 using JustEat.HttpClientInterception;
 using Shouldly;
 using Xunit;
@@ -74,8 +75,10 @@ namespace DotNet.InstallSdk.Tests
             
             using var httpClient = options.ThrowsOnMissingRegistration().CreateHttpClient();
 
+            var a = new GlobalJsonVersion(textWriter);
+            
             new SdkAcquirer(httpClient, textWriter, installerLauncher, platformIdentifier)
-                .Acquire("2.2.100").Wait();
+                .Acquire(a).Wait();
 
             var installerPath = installerLauncher.LastLaunchedInstaller;
             installerPath.ShouldNotBeNullOrEmpty();


### PR DESCRIPTION
This restructuring enables the creation of different 'acquirables', such as:

Download and install version based on:
- global.json
- Latest preview version
- Latest LTS version

etc